### PR TITLE
added custom header tags

### DIFF
--- a/app/templates/layouts/base.html
+++ b/app/templates/layouts/base.html
@@ -2,8 +2,10 @@
 
 <!DOCTYPE html>
 <html>
-    {% include 'partials/_head.html' %}
-
+    <head>
+        {% include 'partials/_head.html' %}
+        {% block custom_scripts %}{% endblock %}
+    </head>
     <body>
         {% block nav %}
             {{ nav.render_nav(current_user) }}

--- a/app/templates/layouts/base.html
+++ b/app/templates/layouts/base.html
@@ -4,7 +4,7 @@
 <html>
     <head>
         {% include 'partials/_head.html' %}
-        {% block custom_scripts %}{% endblock %}
+        {% block custom_tags %}{% endblock %}
     </head>
     <body>
         {% block nav %}
@@ -23,4 +23,5 @@
             </div>
         {% endif %}
     </body>
+    {% block custom_scripts %}{% endblock %}
 </html>

--- a/app/templates/layouts/base.html
+++ b/app/templates/layouts/base.html
@@ -4,7 +4,7 @@
 <html>
     <head>
         {% include 'partials/_head.html' %}
-        {% block custom_tags %}{% endblock %}
+        {% block custom_head_tags %}{% endblock %}
     </head>
     <body>
         {% block nav %}
@@ -23,5 +23,4 @@
             </div>
         {% endif %}
     </body>
-    {% block custom_scripts %}{% endblock %}
 </html>

--- a/app/templates/partials/_head.html
+++ b/app/templates/partials/_head.html
@@ -1,11 +1,9 @@
-<head>
-    <meta name="charset" content="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% block page_title %}{{ config.APP_NAME }}{% endblock %}</title>
+<meta name="charset" content="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{% block page_title %}{{ config.APP_NAME }}{% endblock %}</title>
 
-    {% assets 'vendor_css' %}<link rel="stylesheet" type="text/css" href="{{ ASSET_URL }}">{% endassets %}
-    {% assets 'app_css' %}<link rel="stylesheet" type="text/css" href="{{ ASSET_URL }}">{% endassets %}
+{% assets 'vendor_css' %}<link rel="stylesheet" type="text/css" href="{{ ASSET_URL }}">{% endassets %}
+{% assets 'app_css' %}<link rel="stylesheet" type="text/css" href="{{ ASSET_URL }}">{% endassets %}
 
-    {% assets 'vendor_js' %}<script type="text/javascript" src="{{ ASSET_URL }}"></script>{% endassets %}
-    {% assets 'app_js' %}<script type="text/javascript" src="{{ ASSET_URL }}"></script>{% endassets %}
-</head>
+{% assets 'vendor_js' %}<script type="text/javascript" src="{{ ASSET_URL }}"></script>{% endassets %}
+{% assets 'app_js' %}<script type="text/javascript" src="{{ ASSET_URL }}"></script>{% endassets %}


### PR DESCRIPTION
Problem: Unable to add custom meta tags or script tags to the header specific to individual template files.
Solution: I have edited the `_head.html` file to not restrict what can be added to the head section of the rendered jinja page. As a result, I had to move the opening and closing `<head>` tags into `base.html`. 
Usage: Within a template, after `{% extends 'layouts/base.html' %}` one can define the `custom_scripts` block. E.g.

```
{% extends 'layouts/base.html' %}
{% block custom_scripts %}
<script>console.log('hey there')</script>
{% endblock %}
...
```
