### PR TITLE
Password Checking

### DIFF
--- a/app/templates/account/join_invite.html
+++ b/app/templates/account/join_invite.html
@@ -1,5 +1,6 @@
 {% extends 'layouts/base.html' %}
 {% import 'macros/form_macros.html' as f %}
+{% import 'macros/check_password.html' as check %}
 
 {% block content %}
     <div class="ui grid container">
@@ -8,4 +9,5 @@
             {{ f.render_form(form) }}
         </div>
     </div>
+    {{ check.password_check('password', 0) }}
 {% endblock %}

--- a/app/templates/account/manage.html
+++ b/app/templates/account/manage.html
@@ -1,5 +1,6 @@
 {% extends 'layouts/base.html' %}
 {% import 'macros/form_macros.html' as f %}
+{% import 'macros/check_password.html' as check %}
 
 {% set endpoints = [
     ('account.manage', 'Account information'),
@@ -48,4 +49,5 @@
             </div>
         </div>
     </div>
+    {{ check.password_check('new_password', 0) }}
 {% endblock %}

--- a/app/templates/account/register.html
+++ b/app/templates/account/register.html
@@ -1,5 +1,6 @@
 {% extends 'layouts/base.html' %}
 {% import 'macros/form_macros.html' as f %}
+{% import 'macros/check_password.html' as check %}
 
 {% block content %}
     <div class="ui grid container">
@@ -39,4 +40,5 @@
             {{ f.end_form(form) }}
         </div>
     </div>
+    {{ check.password_check('password', 0) }}
 {% endblock %}

--- a/app/templates/admin/new_user.html
+++ b/app/templates/admin/new_user.html
@@ -1,5 +1,6 @@
 {% extends 'layouts/base.html' %}
 {% import 'macros/form_macros.html' as f %}
+{% import 'macros/check_password.html' as check %}
 
 {% block scripts %}
 {% endblock %}
@@ -53,6 +54,7 @@
                 {% endfor %}
 
             {{ f.end_form() }}
+            {{ check.password_check('password', 0) }}
         </div>
     </div>
 {% endblock %}

--- a/app/templates/macros/check_password.html
+++ b/app/templates/macros/check_password.html
@@ -1,0 +1,66 @@
+{% macro password_check(field) %}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/zxcvbn/4.2.0/zxcvbn.js"></script>
+<script>
+  $('#submit').attr('disabled', true);
+  $('#{{ field }}').after('<meter max="4" id="password-strength-meter"></meter><p id="password-strength-text"></p>');
+  var strength = {
+    0: "Worst",
+    1: "Bad",
+    2: "Weak",
+    3: "Good",
+    4: "Strong"
+  }
+  var meter = document.getElementById('password-strength-meter');
+  var text = $('#password-strength-text');
+
+  $('#{{ field }}').keyup(function() {
+    var result = zxcvbn($(this).val());
+    // Update the password strength meter
+    meter.value = result.score;
+    if(result.score >= 2) {
+      $('#submit').attr('disabled', false);
+    } else {
+      $('#submit').attr('disabled', true);
+    }
+    // Update the text indicator
+    if ($(this).val() !== "") {
+      $(text).html("Strength: " + strength[result.score]); 
+    } else {
+      $(text).html("");
+    }
+  });
+</script>
+<style>
+  meter {
+    /* Reset the default appearance */
+    -webkit-appearance: none;
+       -moz-appearance: none;
+            appearance: none;
+
+    margin: 10 auto 1em;
+    width: 100%;
+    height: 0.5em;
+
+    /* Applicable only to Firefox */
+    background: none;
+    background-color: rgba(0, 0, 0, 0.1);
+  }
+
+  meter::-webkit-meter-bar {
+    background: none;
+    background-color: rgba(0, 0, 0, 0.1);
+  }
+  /* Webkit based browsers */
+  meter[value="1"]::-webkit-meter-optimum-value { background: red; }
+  meter[value="2"]::-webkit-meter-optimum-value { background: yellow; }
+  meter[value="3"]::-webkit-meter-optimum-value { background: orange; }
+  meter[value="4"]::-webkit-meter-optimum-value { background: green; }
+
+  /* Gecko based browsers */
+  meter[value="1"]::-moz-meter-bar { background: red; }
+  meter[value="2"]::-moz-meter-bar { background: yellow; }
+  meter[value="3"]::-moz-meter-bar { background: orange; }
+  meter[value="4"]::-moz-meter-bar { background: green; }
+</style>
+
+{% endmacro %}

--- a/app/templates/macros/check_password.html
+++ b/app/templates/macros/check_password.html
@@ -1,11 +1,11 @@
-{% macro password_check(field) %}
+{% macro password_check(field, level) %}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/zxcvbn/4.2.0/zxcvbn.js"></script>
 <script>
   $('#submit').attr('disabled', true);
-  $('#{{ field }}').after('<meter max="4" id="password-strength-meter"></meter><p id="password-strength-text"></p>');
+  $('#{{ field }}').after('<progress value="0" max="4" id="password-strength-meter"></progress><p id="password-strength-text"></p>');
   var strength = {
-    0: "Worst",
-    1: "Bad",
+    0: "Bad",
+    1: "Okay",
     2: "Good",
     3: "Very Good",
     4: "Strong"
@@ -17,7 +17,7 @@
     var result = zxcvbn($(this).val());
     // Update the password strength meter
     meter.value = result.score;
-    if(result.score >= 2) {
+    if(result.score >= {{ level }}) {
       $('#submit').attr('disabled', false);
     } else {
       $('#submit').attr('disabled', true);
@@ -31,7 +31,7 @@
   });
 </script>
 <style>
-  meter {
+  progress {
     /* Reset the default appearance */
     -webkit-appearance: none;
        -moz-appearance: none;
@@ -40,27 +40,26 @@
     margin: 10 auto 1em;
     width: 100%;
     height: 0.5em;
-
-    /* Applicable only to Firefox */
-    background: none;
     background-color: rgba(0, 0, 0, 0.1);
   }
 
-  meter::-webkit-meter-bar {
-    background: none;
-    background-color: rgba(0, 0, 0, 0.1);
+  /* Chrome */
+  progress::-webkit-progress-value {
+    background: rgba(0, 0, 0, 0.1); 
   }
-  /* Webkit based browsers */
-  meter[value="1"]::-webkit-meter-optimum-value { background: red; }
-  meter[value="2"]::-webkit-meter-optimum-value { background: yellow; }
-  meter[value="3"]::-webkit-meter-optimum-value { background: orange; }
-  meter[value="4"]::-webkit-meter-optimum-value { background: green; }
+
+   /* Webkit based browsers */
+  progress[value^="1"]::-webkit-progress-value { background-color: red; }
+  progress[value^="2"]::-webkit-progress-value { background-color: yellow; }
+  progress[value^="3"]::-webkit-progress-value { background-color: orange; }
+  progress[value^="4"]::-webkit-progress-value { background-color: green; }
+
 
   /* Gecko based browsers */
-  meter[value="1"]::-moz-meter-bar { background: red; }
-  meter[value="2"]::-moz-meter-bar { background: yellow; }
-  meter[value="3"]::-moz-meter-bar { background: orange; }
-  meter[value="4"]::-moz-meter-bar { background: green; }
+  progress[value^="1"]::-moz-progress-bar { background-color: red; }
+  progress[value^="2"]::-moz-progress-bar { background-color: yellow; }
+  progress[value^="3"]::-moz-progress-bar { background-color: orange; }
+  progress[value^="4"]::-moz-progress-bar { background-color: green; }
 </style>
 
 {% endmacro %}

--- a/app/templates/macros/check_password.html
+++ b/app/templates/macros/check_password.html
@@ -6,8 +6,8 @@
   var strength = {
     0: "Worst",
     1: "Bad",
-    2: "Weak",
-    3: "Good",
+    2: "Good",
+    3: "Very Good",
     4: "Strong"
   }
   var meter = document.getElementById('password-strength-meter');


### PR DESCRIPTION
This is a macro implementing zxcvbn password checking on the frontend. Takes in the id for the password field on which the developer wishes to do a strength check. 
Example Usage:
`{{ password_check('password-id-field-name-here`) }}`
Disables submit button until password strength of >= 2 is reached.

Example for the Change Password Page:
On `app/templates/account/manage.html` insert `{% import 'macros/check_password.html' as check %}` and place `{{ check.password_check('new_password') }}` in the line before `{% endblock %}`
Bad Password:
![Bad Password](http://puu.sh/nN7wr/ec04395f52.png)

Strong Password:
![Strong Password](http://puu.sh/nN7xx/3b7830cf94.png)
