### PR TITLE
Generalize SCSS bundle to track all SCSS files

### DIFF
--- a/app/assets.py
+++ b/app/assets.py
@@ -1,7 +1,7 @@
 from flask.ext.assets import Bundle
 
 app_css = Bundle(
-    'app.scss',
+    '*.scss',
     filters='scss',
     output='styles/app.css'
 )


### PR DESCRIPTION
Initially the SCSS bundle only checked for `app.scss` and compiled it to `app.css`.
There are two ways of adding more SCSS files to the bundle: 
1) Explicitly including the name of all SCSS files in the bundle to track 

```
app_css = Bundle(
  'file1.scss',
  'file2.scss',
  'file3.scss'
  filters='scss',
  output='styles/app.css'
)
```

2) Tracking all SCSS files in `assets/styles/`

```
app_css = Bundle(
  '*.scss',
  filters='scss',
  output='styles/app.css'
)
```

Using the second option prevents forgetting to explicitly state each newly added SCSS file and modifying it if the SCSS filename changes. Also, when making more style changes over the entire app, it can be better to create many different SCSS files referring to different templates/areas of the app for better organization, to make it easier to understand and to modify vs. having one large SCSS file. However, since all these SCSS files will compile to one CSS file: `app.css` it can still be easily imported through `partials/_head.html`
