### PR TITLE
Nav refactor

### DIFF
--- a/app/assets/scripts/app.js
+++ b/app/assets/scripts/app.js
@@ -4,7 +4,6 @@ var tabletBreakpoint = '992px';
 var smallMonitorBreakpoint = '1200px';
 
 $(document).ready(function () {
-
     // Enable dismissable flash messages
     $('.message .close').on('click', function () {
         $(this).closest('.message').transition('fade');
@@ -21,9 +20,6 @@ $(document).ready(function () {
     // Enable dropdowns
     $('.dropdown').dropdown();
     $('select').dropdown();
-
-    // mobile dropdown
-    
 });
 
 
@@ -45,14 +41,28 @@ $(document).ready(function () {
             return icontains(elem, match[3]);
         };
 })(jQuery);
- // mobile dropdown menu state change 
-  var currentState = []
-  function changeMenu(e) {
-    var children = $($(e).children()[1]).html();
-    currentState.push($('.mobile.only .vertical.menu').html());
-    children += '<a class="item" onClick="back()">Back</a><i class="back icon"></i>'
-    $('.mobile.only .vertical.menu').html(children);
-  }
-  function back() {
-    $('.mobile.only .vertical.menu').html(currentState.pop());
-  }
+
+
+// mobile dropdown menu state change 
+// This code is used for modeling the state of the mobile dropdown menu. 
+// When a mobile menu item with a dropdown is touched, the changeMenu function
+// is called. It gets all the children of the dropdown and stores them as the
+// children variable. During this time, the state of the dropdown menu is saved
+// into the currentState array for later. A 'back' item that has an onclick attr
+// calling the back() function is appended to the children variable and the
+// html of the mobile dropdown is set to the children variable. 
+// If the back button is clicked, we get the parent menu of the submenu by popping
+// the currentState variable.
+
+var currentState = [];
+
+function changeMenu(e) {
+  var children = $($(e).children()[1]).html();
+  currentState.push($('.mobile.only .vertical.menu').html());
+  children += '<a class="item" onClick="back()">Back</a><i class="back icon"></i>';
+  $('.mobile.only .vertical.menu').html(children);
+}
+
+function back() {
+  $('.mobile.only .vertical.menu').html(currentState.pop());
+}

--- a/app/assets/scripts/app.js
+++ b/app/assets/scripts/app.js
@@ -21,6 +21,9 @@ $(document).ready(function () {
     // Enable dropdowns
     $('.dropdown').dropdown();
     $('select').dropdown();
+
+    // mobile dropdown
+    
 });
 
 
@@ -42,4 +45,14 @@ $(document).ready(function () {
             return icontains(elem, match[3]);
         };
 })(jQuery);
-
+ // mobile dropdown menu state change 
+  var currentState = []
+  function changeMenu(e) {
+    var children = $($(e).children()[1]).html();
+    currentState.push($('.mobile.only .vertical.menu').html());
+    children += '<a class="item" onClick="back()">Back</a><i class="back icon"></i>'
+    $('.mobile.only .vertical.menu').html(children);
+  }
+  function back() {
+    $('.mobile.only .vertical.menu').html(currentState.pop());
+  }

--- a/app/assets/scripts/app.js
+++ b/app/assets/scripts/app.js
@@ -21,8 +21,6 @@ $(document).ready(function () {
     // Enable dropdowns
     $('.dropdown').dropdown();
     $('select').dropdown();
-
-    // mobile dropdown
     
 });
 
@@ -45,14 +43,15 @@ $(document).ready(function () {
             return icontains(elem, match[3]);
         };
 })(jQuery);
- // mobile dropdown menu state change 
-  var currentState = []
-  function changeMenu(e) {
-    var children = $($(e).children()[1]).html();
-    currentState.push($('.mobile.only .vertical.menu').html());
-    children += '<a class="item" onClick="back()">Back</a><i class="back icon"></i>'
-    $('.mobile.only .vertical.menu').html(children);
-  }
-  function back() {
-    $('.mobile.only .vertical.menu').html(currentState.pop());
-  }
+
+// mobile dropdown menu state change 
+var currentState = []
+function changeMenu(e) {
+  var children = $($(e).children()[1]).html();
+  currentState.push($('.mobile.only .vertical.menu').html());
+  children += '<a class="item" onClick="back()">Back</a><i class="back icon"></i>'
+  $('.mobile.only .vertical.menu').html(children);
+}
+function back() {
+  $('.mobile.only .vertical.menu').html(currentState.pop());
+}

--- a/app/templates/layouts/base.html
+++ b/app/templates/layouts/base.html
@@ -4,15 +4,37 @@
 <html>
     <head>
         {% include 'partials/_head.html' %}
+        {# Any templates that extend this template can set custom_head_tags to add scripts to their page #}
         {% block custom_head_tags %}{% endblock %}
     </head>
     <body>
+      {# Example dropdown menu setup. Uncomment lines to view
+        {% set dropdown = 
+          [
+            ('account stuff',
+              [
+                ('account.login', 'login', 'sign in'),
+                ('account.logout', 'logout', 'sign out'),
+                ('2nd drop', [
+                  ('account.login', 'login 2', ''),
+                  ('3rd drop', [
+                    ('main.index', 'home 2', '')
+                  ])
+                ])
+              ]
+            ),
+            ('main.index', 'home 1', 'home')
+          ]
+        %}
+      #}
+
         {% block nav %}
-            {{ nav.render_nav(current_user) }}
+          {# add dropdown variable here to the render_nav method to render dropdowns #}
+          {{ nav.render_nav(current_user) }}
         {% endblock %}
 
         {% include 'partials/_flashes.html' %}
-
+        {# When extended, the content block contains all the html of the webpage #}
         {% block content %}
         {% endblock %}
 

--- a/app/templates/macros/nav_macros.html
+++ b/app/templates/macros/nav_macros.html
@@ -1,3 +1,7 @@
+{# This macro is called on the user dashboards. In this case the administrator dashboard
+   at the route admin.index
+#}
+
 {% macro render_menu_items(endpoints) %}
     {% for endpoint, name, icon in endpoints %}
         <a class="item {% if request.endpoint == endpoint %}active{% endif %}" href="{{ url_for(endpoint) }}">
@@ -9,25 +13,43 @@
     {% endfor %}
 {% endmacro %}
 
+{# This is called for all users (including anonymous users). It renders the basic left side of the 
+   navigation bar. In the default case, the left hand side will read 'Flask-Base'. In the logged in
+   admin case, there will also be an item that links to admin/ route. I have added an example use of
+   render_menu_items.
+#}
+
 {% macro header_items(current_user) %}
-    <a class="header item" href="{{ url_for('main.index') }}">{{ config.APP_NAME }}</a>
+    {% set endpoints = [
+      ('main.index', config.APP_NAME, 'home')
+    ]%}
+    {% set user = [] %}
     {% if current_user.is_authenticated() %}
-        {% set href = url_for(current_user.role.index + '.index') %}
-        <a class="item" href="{{ href }}">{{ current_user.role.name }} Dashboard</a>
-    {% endif %}
+      {% set user = ([(current_user.role.index + '.index', current_user.role.name + ' Dashboard', 'user')]) %}
+    {% endif %} 
+    {{ render_menu_items( endpoints +  user ) }}
 {% endmacro %}
 
+{# This renders the right hand side of the navigation bar. If the user is logged in, it links to 
+   manage their account and logout (account routes). Otherwise, it links to register and login.
+#}
 {% macro account_items(current_user) %}
     {% if current_user.is_authenticated() %}
-        <a href="{{ url_for('account.manage') }}" class="item">Your Account</a>
-        <a href="{{ url_for('account.logout') }}" class="item">Log out</a>
+      {% set endpoints = [
+        ('account.manage', 'Your Account', 'settings'),
+        ('account.logout', 'Log out', 'sign out')
+      ] %}
+      {{ render_menu_items(endpoints) }}
     {% else %}
-        <a href="{{ url_for('account.register') }}" class="item">Register</a>
-        <a href="{{ url_for('account.login') }}" class="item">Log in</a>
+      {% set endpoints = [
+        ('account.register', 'Register', 'list layout'),
+        ('account.login', 'Log In', 'sign in')
+      ] %}
+      {{ render_menu_items(endpoints) }}
     {% endif %}
 {% endmacro %}
 
-{% macro mobile_nav(current_user, endpoints=None) %}
+{% macro mobile_nav(current_user, dropdown=None) %}
     <div class="mobile only row">
         <div class="ui fixed inverted black main menu">
             {{ header_items(current_user) }}
@@ -38,41 +60,43 @@
 
         {# The menu items which will be shown when open-nav is clicked #}
         <div class="ui fixed vertical fluid menu">
-            {% if endpoints %}
-                {{ render_menu_items(endpoints) }}
-            {% endif %}
-            {{ account_items(current_user) }}
+          {{ account_items(current_user) }}
+          {{ create_dropdown(dropdown) }}
         </div>
     </div>
 {% endmacro %}
 
-{# If `count` and `endpoints` are specified, the endpoints will be put into a
- # secondary menu. `count` should be the string (e.g. 'four') number of endpoints. #}
-{% macro desktop_nav(current_user, endpoints=None, count=None) %}
+{% macro create_dropdown(dropdown) %}
+  {% for item in dropdown %}
+    {% if item | length == 3 %}
+      {{ render_menu_items([item]) }}
+    {% elif item | length == 2 %}
+      <div class="ui dropdown item" onClick="changeMenu(this)">{{ item[0] }} <i class="dropdown icon"></i>
+        <div class="inverted black menu">
+          {{ create_dropdown(item[1]) }}
+        </div>
+      </div>
+    {% endif %}
+  {% endfor %}
+{% endmacro %}
+
+{% macro desktop_nav(current_user, dropdown=None) %}
     <div class="computer tablet only row">
         <div class="ui fixed inverted black main menu">
             <div class="ui container">
                 {{ header_items(current_user) }}
+                {{ create_dropdown(dropdown) }}
                 <div class="right menu">
                     {{ account_items(current_user) }}
                 </div>
             </div>
         </div>
-
-        {# Endpoints go into a submenu #}
-        {% if endpoints %}
-            <div class="ui fixed {{ count + ' item' }} labeled icon fluid stackable sub menu">
-                <div class="ui stackable container">
-                    {{ render_menu_items(endpoints) }}
-                </div>
-            </div>
-        {% endif %}
     </div>
 {% endmacro %}
 
-{% macro render_nav(current_user, count, endpoints) %}
+{% macro render_nav(current_user, dropdown=[]) %}
     <nav class="ui navigation grid {% if endpoints %}has-submenu{% endif %}">
-        {{ mobile_nav(current_user, endpoints=endpoints) }}
-        {{ desktop_nav(current_user, endpoints=endpoints, count=count) }}
+        {{ mobile_nav(current_user, dropdown=dropdown) }}
+        {{ desktop_nav(current_user, dropdown=dropdown) }}
     </nav>
 {% endmacro %}


### PR DESCRIPTION
# Navigation Refactoring

A long awaited change to navigation has occurred! Navigation items now default to the `render_menu_item` macro in `nav_macros.html` rather than relying upon hardcoded values. This opens the ability to have active state shown on the user end, vastly improving navigation across the application.
![Navigation Now](http://puu.sh/q04IN/0af4ef4f7f.png)
Additionally Icons are a thing now! 

Lastly, in navigation refactoring, the ability to add a series of submenus has been finally added. 
The following code produces the dropdown scheme seen in the following images.

```
{% set dropdown = 
           [
              ('account stuff',
               [
                ('account.login', 'login', 'sign in'),
                ('account.logout', 'logout', 'sign out'),
                ('2nd drop', [
                  ('account.login', 'login 2', ''),
                  ('3rd drop', [
                    ('main.index', 'home 2', '')
                  ])
                ])
              ]
            ),
            ('main.index', 'home 1', 'home')
          ]
%}
{{ nav.render_nav(current_user, dropdown) }}
```

Desktop:
![Submenus Desktop](http://puu.sh/q04OD/5270de5751.png)

Mobile Part 1:
![Submenus Mobile](http://puu.sh/q04VO/f2b4c2260f.png)

Mobile Part 2:
![Submenus Mobile 2](http://puu.sh/q04Xk/440d53cbd3.png)
