### PR TITLE
require faker not fake-factory

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,2 +1,2 @@
 -r common.txt
-fake-factory==0.5.3
+Faker==0.7.3


### PR DESCRIPTION
@sandlerben @yoninachmany 

Changed the fake-factory requirement to Faker. They are the same thing, but the name is being changed and the old version will be deprecated in December: https://pypi.python.org/pypi/fake-factory
