### PR TITLE
got rid of wsgiref

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ alembic==0.7.6
 blinker==1.3
 itsdangerous==0.24
 webassets==0.10.1
-wsgiref==0.1.2
 redis==2.10.5
 rq==0.5.6
 Faker==0.7.3


### PR DESCRIPTION
looks like this pip module may not be needed also breaks python 3.x compatibility, so I don't see a need to keep it. paging @sandlerben  for code review