### PR TITLE
Update Local to use python3 for honcho tasks

### DIFF
--- a/Local
+++ b/Local
@@ -1,3 +1,3 @@
 redis: redis-server
-web: python -u manage.py runserver
-worker: python -u manage.py run_worker
+web: python3 -u manage.py runserver
+worker: python3 -u manage.py run_worker


### PR DESCRIPTION
Since flask-base now uses python3, I think this is the more correct behavior. @abhisuri97 or @sandlerben can you confirm?