### PR TITLE
Use Markdown style to link logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 [![Circle CI](https://circleci.com/gh/hack4impact/flask-base.svg?style=svg)](https://circleci.com/gh/hack4impact/flask-base) [![Stories in Ready](https://badge.waffle.io/hack4impact/flask-base.png?label=ready&title=Ready)](https://waffle.io/hack4impact/flask-base)
 [![Code Climate](https://codeclimate.com/github/hack4impact/flask-base/badges/gpa.svg)](https://codeclimate.com/github/hack4impact/flask-base/coverage)
 [![Issue Count](https://codeclimate.com/github/hack4impact/flask-base/badges/issue_count.svg)](https://codeclimate.com/github/hack4impact/flask-base) ![python3.x](https://img.shields.io/badge/python-3.x-brightgreen.svg)  ![python2.x](https://img.shields.io/badge/python-2.x-yellow.svg)
-<img src="readme_media/logo@2x.png" width="400"/>
+
+![flask-base](readme_media/logo.png)
 
 A Flask application template with the boilerplate code already done for you.
 


### PR DESCRIPTION
Used `logo.png` instead of `logo@2x.png` because the former's width (500px) is closer to what is currently used (`width="400"`, markdown does not seem to [support](https://guides.github.com/features/mastering-markdown/) `width` tag).