### PR TITLE
Fix RadioField bug in FormMacros

### DIFF
--- a/app/templates/macros/form_macros.html
+++ b/app/templates/macros/form_macros.html
@@ -98,6 +98,7 @@
         </div>
     {% elif field.type == 'RadioField' %}
         {% for item in field %}
+            {{ field.label }}
             <div class="ui radio checkbox">
                 {{ item }}
                 {{ item.label }}

--- a/app/templates/macros/form_macros.html
+++ b/app/templates/macros/form_macros.html
@@ -99,8 +99,8 @@
     {% elif field.type == 'RadioField' %}
         {% for item in field %}
             <div class="ui radio checkbox">
-                {{ field }}
-                {{ field.label }}
+                {{ item }}
+                {{ item.label }}
             </div>
         {% endfor %}
     {% elif field.type == 'SubmitField' %}


### PR DESCRIPTION
The bug is that it iterates over every item in field (`{% for item in field %}`) but then prints `field` rather than `item`