### PR TITLE
[bugfix] issue144. Debug/Testing mode printed when in Production mode.

### DIFF
--- a/config.py
+++ b/config.py
@@ -67,6 +67,7 @@ class Config:
     RQ_DEFAULT_PASSWORD = url.password
     RQ_DEFAULT_DB = 0
 
+
     @staticmethod
     def init_app(app):
         pass
@@ -77,7 +78,11 @@ class DevelopmentConfig(Config):
     ASSETS_DEBUG = True
     SQLALCHEMY_DATABASE_URI = os.environ.get('DEV_DATABASE_URL') or \
         'sqlite:///' + os.path.join(basedir, 'data-dev.sqlite')
-    print('THIS APP IS IN DEBUG MODE. YOU SHOULD NOT SEE THIS IN PRODUCTION.')
+
+
+    @classmethod
+    def init_app(cls, app):
+        print('THIS APP IS IN DEBUG MODE. YOU SHOULD NOT SEE THIS IN PRODUCTION.')
 
 
 class TestingConfig(Config):
@@ -85,6 +90,11 @@ class TestingConfig(Config):
     SQLALCHEMY_DATABASE_URI = os.environ.get('TEST_DATABASE_URL') or \
         'sqlite:///' + os.path.join(basedir, 'data-test.sqlite')
     WTF_CSRF_ENABLED = False
+
+
+    @classmethod
+    def init_app(cls, app):
+        print('THIS APP IS IN TESTING MODE. YOU SHOULD NOT SEE THIS IN PRODUCTION.')
 
 
 class ProductionConfig(Config):


### PR DESCRIPTION
Hi team,

I love your work, great project! I noticed some undesired behaviour when running in prod mode, which was the printing of a statement saying that flask-base is in debug mode. This has been flagged by a previous used under open issue #144 .

The offending print statement was part of the class definition for DevelopmentConfig but not inside of a method, so it will printed every time the python interpreter reads the file e.g. from config import config.

My proposed solution is to wrap the print statement in .init_app() methods to the Dev and Testing Config classes. 

Hope this works for you!