### PR TITLE
Properly use the default parameter of get()

### DIFF
--- a/config.py
+++ b/config.py
@@ -99,7 +99,7 @@ class TestingConfig(Config):
 class ProductionConfig(Config):
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL',
         'sqlite:///' + os.path.join(basedir, 'data.sqlite'))
-    SSL_DISABLE = (os.environ.get('SSL_DISABLE', 'True') == 'True'
+    SSL_DISABLE = (os.environ.get('SSL_DISABLE', 'True') == 'True')
 
     @classmethod
     def init_app(cls, app):

--- a/config.py
+++ b/config.py
@@ -20,7 +20,7 @@ if os.path.exists('config.env'):
 
 
 class Config:
-    APP_NAME = os.environ.get('APP_NAME') or 'Flask-Base'
+    APP_NAME = os.environ.get('APP_NAME', 'Flask-Base')
 
     if os.environ.get('SECRET_KEY'):
         SECRET_KEY = os.environ.get('SECRET_KEY')
@@ -30,27 +30,27 @@ class Config:
     SQLALCHEMY_COMMIT_ON_TEARDOWN = True
 
     # Email
-    MAIL_SERVER = os.environ.get('MAIL_SERVER') or 'smtp.sendgrid.net'
-    MAIL_PORT = os.environ.get('MAIL_PORT') or 587
-    MAIL_USE_TLS = os.environ.get('MAIL_USE_TLS') or True
-    MAIL_USE_SSL = os.environ.get('MAIL_USE_SSL') or False
+    MAIL_SERVER = os.environ.get('MAIL_SERVER', 'smtp.sendgrid.net')
+    MAIL_PORT = os.environ.get('MAIL_PORT', 587)
+    MAIL_USE_TLS = os.environ.get('MAIL_USE_TLS', True)
+    MAIL_USE_SSL = os.environ.get('MAIL_USE_SSL', False)
     MAIL_USERNAME = os.environ.get('MAIL_USERNAME')
     MAIL_PASSWORD = os.environ.get('MAIL_PASSWORD')
     MAIL_DEFAULT_SENDER = os.environ.get('MAIL_DEFAULT_SENDER')
 
     # Analytics
-    GOOGLE_ANALYTICS_ID = os.environ.get('GOOGLE_ANALYTICS_ID') or ''
-    SEGMENT_API_KEY = os.environ.get('SEGMENT_API_KEY') or ''
+    GOOGLE_ANALYTICS_ID = os.environ.get('GOOGLE_ANALYTICS_ID', '')
+    SEGMENT_API_KEY = os.environ.get('SEGMENT_API_KEY', '')
 
     # Admin account
-    ADMIN_PASSWORD = os.environ.get('ADMIN_PASSWORD') or 'password'
+    ADMIN_PASSWORD = os.environ.get('ADMIN_PASSWORD', 'password')
     ADMIN_EMAIL = os.environ.get(
-        'ADMIN_EMAIL') or 'flask-base-admin@example.com'
+        'ADMIN_EMAIL', 'flask-base-admin@example.com')
     EMAIL_SUBJECT_PREFIX = '[{}]'.format(APP_NAME)
     EMAIL_SENDER = '{app_name} Admin <{email}>'.format(
         app_name=APP_NAME, email=MAIL_USERNAME)
 
-    REDIS_URL = os.getenv('REDISTOGO_URL') or 'http://localhost:6379'
+    REDIS_URL = os.getenv('REDISTOGO_URL', 'http://localhost:6379')
 
     RAYGUN_APIKEY = os.environ.get('RAYGUN_APIKEY')
 
@@ -75,8 +75,8 @@ class Config:
 class DevelopmentConfig(Config):
     DEBUG = True
     ASSETS_DEBUG = True
-    SQLALCHEMY_DATABASE_URI = os.environ.get('DEV_DATABASE_URL') or \
-        'sqlite:///' + os.path.join(basedir, 'data-dev.sqlite')
+    SQLALCHEMY_DATABASE_URI = os.environ.get('DEV_DATABASE_URL',
+        'sqlite:///' + os.path.join(basedir, 'data-dev.sqlite'))
 
     @classmethod
     def init_app(cls, app):
@@ -86,8 +86,8 @@ class DevelopmentConfig(Config):
 
 class TestingConfig(Config):
     TESTING = True
-    SQLALCHEMY_DATABASE_URI = os.environ.get('TEST_DATABASE_URL') or \
-        'sqlite:///' + os.path.join(basedir, 'data-test.sqlite')
+    SQLALCHEMY_DATABASE_URI = os.environ.get('TEST_DATABASE_URL',
+        'sqlite:///' + os.path.join(basedir, 'data-test.sqlite'))
     WTF_CSRF_ENABLED = False
 
     @classmethod
@@ -97,9 +97,9 @@ class TestingConfig(Config):
 
 
 class ProductionConfig(Config):
-    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or \
-        'sqlite:///' + os.path.join(basedir, 'data.sqlite')
-    SSL_DISABLE = (os.environ.get('SSL_DISABLE') or 'True') == 'True'
+    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL',
+        'sqlite:///' + os.path.join(basedir, 'data.sqlite'))
+    SSL_DISABLE = (os.environ.get('SSL_DISABLE', 'True') == 'True'
 
     @classmethod
     def init_app(cls, app):


### PR DESCRIPTION
Using `dict.get('key') or True` means that key can never be False! And
in other cases, it's just clearer and more compact to use the default
parameter.

I ran into this when I was trying to disable TLS so I could use the Python [SMTPd](https://opensourcehacker.com/2013/04/26/debug-smtp-server-one-liner/) for debugging mail. TLS was always on, even when I set `MAIL_USE_TLS=` in the config.env file. I eventually discovered that it was because that was turning into a True value after processing the file.

Note that the behavior has also changed for `SSL_DISABLE`, which is being compared to the string 'True'. If it was left blank as `SSL_DISABLE=`, then it would turn into True. Now it will register an empty string in the .env file as False.