### PR TITLE
set debugger and reloader to False on production

### DIFF
--- a/config.py
+++ b/config.py
@@ -97,6 +97,8 @@ class TestingConfig(Config):
 
 
 class ProductionConfig(Config):
+    DEBUG = False
+    USE_RELOADER = False
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL',
         'sqlite:///' + os.path.join(basedir, 'data.sqlite'))
     SSL_DISABLE = (os.environ.get('SSL_DISABLE', 'True') == 'True')


### PR DESCRIPTION
Isn't it will be better if set debugger and reloader to False on production..?