### PR TITLE
Migrating to Flask-Mail-SendGrid and API Key authentication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A Flask application template with the boilerplate code already done for you.
 * Flask-SQLAlchemy for databases
 * Flask-WTF for forms
 * Flask-Assets for asset management and SCSS compilation
-* Flask-Mail for sending emails
+* Flask-Mail-SendGrid for sending emails
 * gzip compression
 * Redis Queue for handling asynchronous tasks
 * ZXCVBN password strength checker
@@ -97,11 +97,11 @@ Variables declared in file have the following format: `ENVIRONMENT_VARIABLE=valu
    ```
 
 2. The mailing environment variables can be set as the following.
-   We recommend using [Sendgrid](https://sendgrid.com) for a mailing SMTP server, but anything else will work as well.
+   We recommend using [Sendgrid](https://sendgrid.com).
 
    ```
-   MAIL_USERNAME=SendgridUsername
-   MAIL_PASSWORD=SendgridPassword
+   MAIL_SENDGRID_API_KEY=YourSendGridAPIKey
+   MAIL_DEFAULT_SENDER=noreply@example.com
    ```
 
 Other useful variables include:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,7 @@ from flask import Flask
 from flask_assets import Environment
 from flask_compress import Compress
 from flask_login import LoginManager
-from flask_mail import Mail
+from flask_mail_sendgrid import MailSendGrid as Mail
 from flask_rq import RQ
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf import CSRFProtect

--- a/config.py
+++ b/config.py
@@ -30,12 +30,7 @@ class Config:
     SQLALCHEMY_COMMIT_ON_TEARDOWN = True
 
     # Email
-    MAIL_SERVER = os.environ.get('MAIL_SERVER', 'smtp.sendgrid.net')
-    MAIL_PORT = os.environ.get('MAIL_PORT', 587)
-    MAIL_USE_TLS = os.environ.get('MAIL_USE_TLS', True)
-    MAIL_USE_SSL = os.environ.get('MAIL_USE_SSL', False)
-    MAIL_USERNAME = os.environ.get('MAIL_USERNAME')
-    MAIL_PASSWORD = os.environ.get('MAIL_PASSWORD')
+    MAIL_SENDGRID_API_KEY = os.environ.get('MAIL_SENDGRID_API_KEY')
     MAIL_DEFAULT_SENDER = os.environ.get('MAIL_DEFAULT_SENDER')
 
     # Analytics
@@ -48,7 +43,7 @@ class Config:
         'ADMIN_EMAIL', 'flask-base-admin@example.com')
     EMAIL_SUBJECT_PREFIX = '[{}]'.format(APP_NAME)
     EMAIL_SENDER = '{app_name} Admin <{email}>'.format(
-        app_name=APP_NAME, email=MAIL_USERNAME)
+        app_name=APP_NAME, email=MAIL_DEFAULT_SENDER)
 
     REDIS_URL = os.getenv('REDISTOGO_URL', 'http://localhost:6379')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Flask==1.1.1
 Flask-Assets==0.12
 Flask-Compress==1.4.0
 Flask-Login==0.4.1
-Flask-Mail==0.9.1
+Flask-Mail-SendGrid==0.3
 Flask-Migrate==2.5.2
 Flask-RQ==0.2
 Flask-Script==2.0.6


### PR DESCRIPTION
SendGrid has deprecated basic authentication in favor of API key authentication. On one hand, this change locks
this project template into using SendGrid, but on the other, provides a touch better security out of the gate.

I also edited the README to reflect the change.

Please feel free to reject this change if you prefer SMTP-based flexibility over an extension locking in to one
provider. I just migrated my own project and it was a low lift to send this your way as well!