### PR TITLE
Added specific version numbers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ ENV SECRET_KEY=SuperRandomStringToBeUsedForEncryption
 COPY ./requirements.txt /app/requirements.txt
 
 WORKDIR /app
-RUN pip3 install -r requirements.txt 
+RUN pip3 install -r requirements.txt
 ENV PYTHONIOENCODING=UTF-8
-RUN pip3 install sqlalchemy_utils flask_dance flask_caching python-gitlab
+RUN pip3 install sqlalchemy_utils==0.38.3 flask_dance==5.1.0 Flask-Caching==1.11.1 python-gitlab==3.10.0
 
 COPY . /app
 

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -14,7 +14,7 @@ COPY ./requirements.txt /app/requirements.txt
 WORKDIR /app
 RUN pip3 install -r requirements.txt 
 ENV PYTHONIOENCODING=UTF-8
-RUN pip3 install sqlalchemy_utils flask_dance flask_caching python-gitlab
+RUN pip3 install sqlalchemy_utils==0.38.3 flask_dance==5.1.0 Flask-Caching==1.11.1 python-gitlab==3.10.0
 
 COPY . /app
 


### PR DESCRIPTION
As I found out in issue #223, running `docker-compose up` as it is causes errors.
Turns out the reason for this is that no version numbers are specified for the pip requirements in both Dockerfiles.

Without a version number being specified, the latest versions of **flask_dance** and **Flask-Caching** are being used. These latest version install **Flask > 2.0** as a dependency, as well as a incompatible version of **Werkzeug**. This results in ` from flask._compat import text_type` and `'safe_str_cmp' from 'werkzeug.security'` not being found (and most certainly more issues down the road) .

I fixed this by downgrading version by version and checking the dependencies until Flask 1.X was fine and the errors disappeared. At this point I also froze the version numbers of **python-gitlab** and **sqlalchemy_utils**.