### PR TITLE
fix: added ruby sass dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ FROM python:3.8-alpine
 # Packages required for psycopg2
 RUN apk update && apk add postgresql-dev gcc python3-dev musl-dev
 
+# Ruby sass
+RUN apk add make ruby-dev
+RUN gem install sass
+
 #MAINTANER Your Name "youremail@domain.tld"
 ENV MAIL_USERNAME=yourmail@test.com
 ENV MAIL_PASSWORD=testpass


### PR DESCRIPTION
With how the docker-compose is, everything seems to work fine until you touch the css. Then you get error `webassets.exceptions.FilterError: Program file not found: sass.`

This commit fixes that by installing sass through the Dockerfile. I don't believe the worker needs this, hence it's only in the Dockerfile for the server.

PS: I had a merged PR in October, that dealt with making the docker-compose work out of the box, this is the second error I encountered during my journey, that I never got around to open a PR for. 